### PR TITLE
1.0.4 Bug Fixes

### DIFF
--- a/Assets/Audio/Gearbox Minigame/GearMoving.mp3.import
+++ b/Assets/Audio/Gearbox Minigame/GearMoving.mp3.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/GearMoving.mp3-cdf8533241f04de0349667acda8c9b
 
 [params]
 
-loop=false
-loop_offset=0
-bpm=0
+loop=true
+loop_offset=0.0
+bpm=0.0
 beat_count=0
 bar_beats=4

--- a/Scenes/Cutscenes/post_cooking_scene.tscn
+++ b/Scenes/Cutscenes/post_cooking_scene.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=14 format=3 uid="uid://djpx22k4xnkwv"]
+[gd_scene load_steps=15 format=3 uid="uid://djpx22k4xnkwv"]
 
 [ext_resource type="Script" uid="uid://dunu3vmcn6cmy" path="res://Scripts/Cutscenes/post_cooking_scene.gd" id="1_citul"]
 [ext_resource type="Texture2D" uid="uid://brrqynw57auwm" path="res://Assets/Images/Lighthouse/Structure/FullTowerBuild2.png" id="1_h2r2y"]
 [ext_resource type="Texture2D" uid="uid://bqwod0spj8tjt" path="res://Assets/Images/Lighthouse/Props/Post-Bombing/Cracks.png" id="2_citul"]
+[ext_resource type="PackedScene" uid="uid://cpmufmthgj1px" path="res://Scenes/Environments/animated_snow_map.tscn" id="2_dvlir"]
 [ext_resource type="Texture2D" uid="uid://dus3k2emrwltj" path="res://Assets/Images/Lighthouse/Props/Kitchen and Dining Room/fridge.png" id="3_tr1ao"]
 [ext_resource type="Texture2D" uid="uid://j420r5weyj55" path="res://Assets/Images/Lighthouse/Props/Kitchen and Dining Room/kitchen.png" id="4_dvlir"]
 [ext_resource type="Texture2D" uid="uid://b6hm6oy6xlks1" path="res://Assets/Images/Lighthouse/Props/Kitchen and Dining Room/washing-machine.png" id="5_w0dos"]
@@ -23,6 +24,11 @@ width = 1
 position = Vector2(-19.133606, -75.7584)
 scale = Vector2(1.176044, 1.176044)
 script = ExtResource("1_citul")
+
+[node name="AnimatedSnowMap" parent="." instance=ExtResource("2_dvlir")]
+visible = true
+position = Vector2(-292.7677, -116.89287)
+scale = Vector2(3.7837167, 3.7837167)
 
 [node name="LightHouse" type="Sprite2D" parent="."]
 position = Vector2(345, -586)

--- a/Scenes/UI/start_menu_bad_end.tscn
+++ b/Scenes/UI/start_menu_bad_end.tscn
@@ -1,206 +1,127 @@
-[gd_scene load_steps=56 format=3 uid="uid://bf5g134nk8ebe"]
+[gd_scene load_steps=55 format=3 uid="uid://dq75ao1vn2g22"]
 
-[ext_resource type="Script" uid="uid://ch3y31u7yadh8" path="res://Scripts/UI/start_menu.gd" id="1_juhg0"]
-[ext_resource type="Texture2D" uid="uid://jx3yb0oa748d" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/LighthouseAnim2.png" id="2_qpngb"]
-[ext_resource type="FontFile" uid="uid://bugymcbk132rp" path="res://Assets/Fonts/Fry's Baskerville Regular.otf" id="3_2ybwg"]
-[ext_resource type="Theme" uid="uid://b4lurv8njswua" path="res://Resources/theme.tres" id="3_3kyvb"]
-[ext_resource type="FontFile" uid="uid://n0n6mmkjc76j" path="res://Assets/Fonts/Eyesome Script.otf" id="3_8wf1d"]
-[ext_resource type="PackedScene" uid="uid://cnhqsrc4gxenp" path="res://Scenes/UI/options_panel.tscn" id="6_4j130"]
-[ext_resource type="Texture2D" uid="uid://cl5m1ag2c73rw" path="res://Socials/instagramLogo.png" id="6_6aj3n"]
-[ext_resource type="Texture2D" uid="uid://ofq8rlceejkj" path="res://Socials/itch.ioLogo.png" id="7_flpep"]
-[ext_resource type="Texture2D" uid="uid://nqv7yxtq17yu" path="res://Socials/X_TwitterLogo_Inverted.png" id="8_4j130"]
-[ext_resource type="Texture2D" uid="uid://clrkcs60j62i7" path="res://Socials/githubLogo.png" id="8_dapwv"]
-[ext_resource type="Texture2D" uid="uid://dyat81sk4l0my" path="res://Socials/TikTokLogo.png" id="9_flpep"]
-[ext_resource type="Texture2D" uid="uid://c183q4u3evnkt" path="res://Socials/RedditLogo.png" id="11_dotjr"]
-[ext_resource type="Texture2D" uid="uid://c4yt30qi4s5pu" path="res://Socials/soundCloudLogo.png" id="12_8hnkv"]
-[ext_resource type="Texture2D" uid="uid://da5s4no21relq" path="res://Socials/bandLabLogo.png" id="13_1gelb"]
-[ext_resource type="Texture2D" uid="uid://dby8t5470r2bp" path="res://Socials/linkedInLogo.png" id="14_1gelb"]
-[ext_resource type="Texture2D" uid="uid://wdrj1fxdpqm8" path="res://Socials/artStationLogo.png" id="16_28ark"]
+[ext_resource type="Script" uid="uid://ch3y31u7yadh8" path="res://Scripts/UI/start_menu.gd" id="1_x7740"]
+[ext_resource type="Texture2D" uid="uid://dhrmvq1g1trpl" path="res://Assets/Images/Cutscenes/SmokePlume/frame0000.png" id="2_pruqg"]
+[ext_resource type="Texture2D" uid="uid://d22r2unu8fgyv" path="res://Assets/Images/Cutscenes/SmokePlume/frame0001.png" id="3_tp1dt"]
+[ext_resource type="Texture2D" uid="uid://cqd822daygrrg" path="res://Assets/Images/Cutscenes/SmokePlume/frame0002.png" id="4_yfqq1"]
+[ext_resource type="Texture2D" uid="uid://crstaupxpuw0a" path="res://Assets/Images/Cutscenes/SmokePlume/frame0003.png" id="5_7551c"]
+[ext_resource type="Texture2D" uid="uid://cxhdjosr13wxu" path="res://Assets/Images/Cutscenes/SmokePlume/frame0004.png" id="6_e84b8"]
+[ext_resource type="Texture2D" uid="uid://dvaisyp7egbh3" path="res://Assets/Images/Cutscenes/SmokePlume/frame0005.png" id="7_ct2x3"]
+[ext_resource type="Texture2D" uid="uid://ctst6lkrj6k2a" path="res://Assets/Images/Cutscenes/SmokePlume/frame0006.png" id="8_nlmy1"]
+[ext_resource type="Texture2D" uid="uid://d03npra10xtk5" path="res://Assets/Images/Cutscenes/SmokePlume/frame0007.png" id="9_pc0xo"]
+[ext_resource type="Texture2D" uid="uid://dcyrssx3b8iee" path="res://Assets/Images/Cutscenes/SmokePlume/frame0008.png" id="10_sht8d"]
+[ext_resource type="Texture2D" uid="uid://yypuqgmtxnyw" path="res://Assets/Images/Cutscenes/SmokePlume/frame0009.png" id="11_04keo"]
+[ext_resource type="Texture2D" uid="uid://me5bmnh1gpvh" path="res://Assets/Images/Cutscenes/SmokePlume/frame0010.png" id="12_sgyms"]
+[ext_resource type="Texture2D" uid="uid://vpuronsfa78p" path="res://Assets/Images/Cutscenes/SmokePlume/frame0011.png" id="13_r1q8w"]
+[ext_resource type="Texture2D" uid="uid://sjoh48tdhroh" path="res://Assets/Images/Cutscenes/SmokePlume/frame0012.png" id="14_tg1ra"]
+[ext_resource type="Texture2D" uid="uid://cnb2015j41lvv" path="res://Assets/Images/Cutscenes/SmokePlume/frame0013.png" id="15_jr03n"]
+[ext_resource type="Texture2D" uid="uid://cemdp0v16o15r" path="res://Assets/Images/Cutscenes/SmokePlume/frame0014.png" id="16_kcuyj"]
+[ext_resource type="Texture2D" uid="uid://dgdpjlxuqe5er" path="res://Assets/Images/Cutscenes/SmokePlume/frame0015.png" id="17_scce1"]
+[ext_resource type="Texture2D" uid="uid://bs6girhqw4ift" path="res://Assets/Images/Cutscenes/SmokePlume/frame0016.png" id="18_sufwb"]
+[ext_resource type="Texture2D" uid="uid://dcd0nwcaefwej" path="res://Assets/Images/Cutscenes/SmokePlume/frame0017.png" id="19_vtj17"]
+[ext_resource type="Texture2D" uid="uid://rxicku0v7h1j" path="res://Assets/Images/Cutscenes/SmokePlume/frame0018.png" id="20_lo7j0"]
+[ext_resource type="Texture2D" uid="uid://cu24wv3a2nfpu" path="res://Assets/Images/Cutscenes/SmokePlume/frame0019.png" id="21_acx7n"]
+[ext_resource type="Texture2D" uid="uid://chytcssutob6j" path="res://Assets/Images/Cutscenes/SmokePlume/frame0020.png" id="22_c7b8u"]
+[ext_resource type="Texture2D" uid="uid://cqiyynsfoedy5" path="res://Assets/Images/Cutscenes/SmokePlume/frame0021.png" id="23_4av6w"]
+[ext_resource type="Texture2D" uid="uid://3s2w347accm2" path="res://Assets/Images/Cutscenes/SmokePlume/frame0022.png" id="24_jxq4o"]
+[ext_resource type="Texture2D" uid="uid://btcuejgroefli" path="res://Assets/Images/Cutscenes/SmokePlume/frame0023.png" id="25_5iclm"]
+[ext_resource type="Texture2D" uid="uid://yvosi5ib6l6i" path="res://Assets/Images/Cutscenes/SmokePlume/frame0024.png" id="26_40nkd"]
+[ext_resource type="Texture2D" uid="uid://cwxksaxjk6yam" path="res://Assets/Images/Cutscenes/SmokePlume/frame0025.png" id="27_hv4fk"]
+[ext_resource type="FontFile" uid="uid://n0n6mmkjc76j" path="res://Assets/Fonts/Eyesome Script.otf" id="28_nnuji"]
+[ext_resource type="Theme" uid="uid://b4lurv8njswua" path="res://Resources/theme.tres" id="29_fhwr0"]
+[ext_resource type="FontFile" uid="uid://bugymcbk132rp" path="res://Assets/Fonts/Fry's Baskerville Regular.otf" id="30_01fsn"]
+[ext_resource type="PackedScene" uid="uid://cnhqsrc4gxenp" path="res://Scenes/UI/options_panel.tscn" id="31_76mws"]
+[ext_resource type="Texture2D" uid="uid://cl5m1ag2c73rw" path="res://Socials/instagramLogo.png" id="32_ii1fg"]
+[ext_resource type="Texture2D" uid="uid://clrkcs60j62i7" path="res://Socials/githubLogo.png" id="33_dk04g"]
+[ext_resource type="Texture2D" uid="uid://ofq8rlceejkj" path="res://Socials/itch.ioLogo.png" id="34_883rd"]
+[ext_resource type="Texture2D" uid="uid://nqv7yxtq17yu" path="res://Socials/X_TwitterLogo_Inverted.png" id="35_rg5xd"]
+[ext_resource type="Texture2D" uid="uid://dyat81sk4l0my" path="res://Socials/TikTokLogo.png" id="36_poak7"]
+[ext_resource type="Texture2D" uid="uid://c183q4u3evnkt" path="res://Socials/RedditLogo.png" id="37_nvrlp"]
+[ext_resource type="Texture2D" uid="uid://c4yt30qi4s5pu" path="res://Socials/soundCloudLogo.png" id="38_knt6f"]
+[ext_resource type="Texture2D" uid="uid://da5s4no21relq" path="res://Socials/bandLabLogo.png" id="39_pgrap"]
+[ext_resource type="Texture2D" uid="uid://dby8t5470r2bp" path="res://Socials/linkedInLogo.png" id="40_kdcmi"]
+[ext_resource type="Texture2D" uid="uid://wdrj1fxdpqm8" path="res://Socials/artStationLogo.png" id="41_kcw8g"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_8wf1d"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(0, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_2ybwg"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(480, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_3kyvb"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(960, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_fa70d"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(1440, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_j6k6k"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(1920, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6aj3n"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(2400, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_flpep"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(2880, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_4j130"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(3360, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_dotjr"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(3840, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_vxxty"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(4320, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_8hnkv"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(4800, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_1gelb"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(5280, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_dapwv"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(5760, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_28ark"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(6240, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_g8uic"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(6720, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_0v2ic"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(7200, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ee1bv"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(7680, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_sv1v3"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(8160, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_4rjbl"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(8640, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6q7j5"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(9120, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ho5tr"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(9600, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_mj5xc"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(10080, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_5tb6a"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(10560, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_82exy"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(11040, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6pru2"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(11520, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_58o8m"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(12000, 0, 480, 270)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_yxcpp"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_idqw4"]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_8wf1d")
+"texture": ExtResource("2_pruqg")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_2ybwg")
+"texture": ExtResource("3_tp1dt")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_3kyvb")
+"texture": ExtResource("4_yfqq1")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_fa70d")
+"texture": ExtResource("5_7551c")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_j6k6k")
+"texture": ExtResource("6_e84b8")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_6aj3n")
+"texture": ExtResource("7_ct2x3")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_flpep")
+"texture": ExtResource("8_nlmy1")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_4j130")
+"texture": ExtResource("9_pc0xo")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_dotjr")
+"texture": ExtResource("10_sht8d")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_vxxty")
+"texture": ExtResource("11_04keo")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_8hnkv")
+"texture": ExtResource("12_sgyms")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_1gelb")
+"texture": ExtResource("13_r1q8w")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_dapwv")
+"texture": ExtResource("14_tg1ra")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_28ark")
+"texture": ExtResource("15_jr03n")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_g8uic")
+"texture": ExtResource("16_kcuyj")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_0v2ic")
+"texture": ExtResource("17_scce1")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ee1bv")
+"texture": ExtResource("18_sufwb")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_sv1v3")
+"texture": ExtResource("19_vtj17")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_4rjbl")
+"texture": ExtResource("20_lo7j0")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_6q7j5")
+"texture": ExtResource("21_acx7n")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ho5tr")
+"texture": ExtResource("22_c7b8u")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_mj5xc")
+"texture": ExtResource("23_4av6w")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_5tb6a")
+"texture": ExtResource("24_jxq4o")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_82exy")
+"texture": ExtResource("25_5iclm")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_6pru2")
+"texture": ExtResource("26_40nkd")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_58o8m")
+"texture": ExtResource("27_hv4fk")
 }],
 "loop": true,
 "name": &"default",
@@ -232,8 +153,16 @@ bg_color = Color(0.13725491, 0.12156863, 0.1254902, 0.9019608)
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ee1bv"]
 
-[node name="StartMenu" type="Control"]
+[node name="Control" type="Control"]
 layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="StartMenu" type="Control" parent="."]
+layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -242,14 +171,14 @@ offset_right = 1.0
 offset_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_juhg0")
+script = ExtResource("1_x7740")
 
-[node name="TextureRect" type="AnimatedSprite2D" parent="."]
+[node name="TextureRect" type="AnimatedSprite2D" parent="StartMenu"]
 position = Vector2(575, 324)
 scale = Vector2(2.3999999, 2.4000003)
-sprite_frames = SubResource("SpriteFrames_yxcpp")
+sprite_frames = SubResource("SpriteFrames_idqw4")
 
-[node name="Title" type="RichTextLabel" parent="."]
+[node name="Title" type="RichTextLabel" parent="StartMenu"]
 texture_filter = 1
 layout_mode = 0
 offset_left = 509.0
@@ -258,13 +187,13 @@ offset_right = 1921.0
 offset_bottom = 894.0
 scale = Vector2(0.4954999, 0.5062728)
 theme_override_colors/default_color = Color(0.8745098, 0.8980392, 0.7294118, 1)
-theme_override_fonts/normal_font = ExtResource("3_8wf1d")
+theme_override_fonts/normal_font = ExtResource("28_nnuji")
 theme_override_font_sizes/normal_font_size = 512
 text = "Solais"
 scroll_active = false
 autowrap_mode = 0
 
-[node name="CenterContainer" type="CenterContainer" parent="."]
+[node name="CenterContainer" type="CenterContainer" parent="StartMenu"]
 layout_mode = 1
 offset_left = 464.0
 offset_top = 378.0
@@ -272,72 +201,72 @@ offset_right = 717.0
 offset_bottom = 689.0
 scale = Vector2(0.79494154, 0.8267256)
 
-[node name="Buttons" type="VBoxContainer" parent="CenterContainer"]
+[node name="Buttons" type="VBoxContainer" parent="StartMenu/CenterContainer"]
 texture_filter = 1
 layout_mode = 2
 theme_override_constants/separation = 4
 
-[node name="StartButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="StartButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("29_fhwr0")
+theme_override_fonts/font = ExtResource("30_01fsn")
 theme_override_font_sizes/font_size = 49
 action_mode = 0
 text = " New Game "
 
-[node name="ContinueButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="ContinueButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("29_fhwr0")
+theme_override_fonts/font = ExtResource("30_01fsn")
 theme_override_font_sizes/font_size = 49
 text = "Continue
 "
 
-[node name="OptionsButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="OptionsButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("29_fhwr0")
+theme_override_fonts/font = ExtResource("30_01fsn")
 theme_override_font_sizes/font_size = 49
 text = "Options"
 
-[node name="SocialsButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="SocialsButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("29_fhwr0")
+theme_override_fonts/font = ExtResource("30_01fsn")
 theme_override_font_sizes/font_size = 49
 text = "Links"
 
-[node name="QuitButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="QuitButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("29_fhwr0")
+theme_override_fonts/font = ExtResource("30_01fsn")
 theme_override_font_sizes/font_size = 49
 text = "Quit
 "
 
-[node name="OptionsPanel" parent="." instance=ExtResource("6_4j130")]
+[node name="OptionsPanel" parent="StartMenu" instance=ExtResource("31_76mws")]
 layout_mode = 0
 
-[node name="SocialsPanel" type="Panel" parent="."]
+[node name="SocialsPanel" type="Panel" parent="StartMenu"]
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 39.644794
 scale = Vector2(28.731138, 16.37037)
 theme_override_styles/panel = SubResource("StyleBoxFlat_flpep")
 
-[node name="githubRepoButton" type="Button" parent="SocialsPanel"]
+[node name="githubRepoButton" type="Button" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 17.518091
 offset_top = 17.172277
 offset_right = 160.77611
 offset_bottom = 173.42276
 scale = Vector2(0.027727112, 0.046241343)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -349,29 +278,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("8_dapwv")
+icon = ExtResource("33_dk04g")
 icon_alignment = 1
 expand_icon = true
 
-[node name="CyberSugar" type="Label" parent="SocialsPanel"]
+[node name="CyberSugar" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 1.9142996
 offset_top = 7.387984
 offset_right = 955.9143
 offset_bottom = 147.38799
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 116
 text = "CyberSugar Studios"
 
-[node name="instagramButton" type="Button" parent="SocialsPanel/CyberSugar"]
+[node name="instagramButton" type="Button" parent="StartMenu/SocialsPanel/CyberSugar"]
 layout_mode = 0
 offset_left = 23.590847
 offset_top = 147.05228
 offset_right = 166.84886
 offset_bottom = 303.3028
 scale = Vector2(1.1234008, 1)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -383,11 +312,11 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("6_6aj3n")
+icon = ExtResource("32_ii1fg")
 icon_alignment = 1
 expand_icon = true
 
-[node name="itchButton" type="Button" parent="SocialsPanel/CyberSugar"]
+[node name="itchButton" type="Button" parent="StartMenu/SocialsPanel/CyberSugar"]
 layout_mode = 0
 offset_left = 191.34787
 offset_top = 139.57506
@@ -405,11 +334,11 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("7_flpep")
+icon = ExtResource("34_883rd")
 icon_alignment = 1
 expand_icon = true
 
-[node name="xButton" type="Button" parent="SocialsPanel/CyberSugar"]
+[node name="xButton" type="Button" parent="StartMenu/SocialsPanel/CyberSugar"]
 layout_mode = 0
 offset_left = 364.34726
 offset_top = 147.05226
@@ -427,11 +356,11 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("8_4j130")
+icon = ExtResource("35_rg5xd")
 icon_alignment = 1
 expand_icon = true
 
-[node name="tikTokButton" type="Button" parent="SocialsPanel/CyberSugar"]
+[node name="tikTokButton" type="Button" parent="StartMenu/SocialsPanel/CyberSugar"]
 layout_mode = 0
 offset_left = 524.2407
 offset_top = 134.59023
@@ -449,22 +378,22 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("9_flpep")
+icon = ExtResource("36_poak7")
 icon_alignment = 1
 expand_icon = true
 
-[node name="NyxForge Studio" type="Label" parent="SocialsPanel"]
+[node name="NyxForge Studio" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 23.406216
 offset_top = 6.285019
 offset_right = 977.4062
 offset_bottom = 146.28502
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 116
 text = "NyxForge Studio"
 
-[node name="itchButton" type="Button" parent="SocialsPanel/NyxForge Studio"]
+[node name="itchButton" type="Button" parent="StartMenu/SocialsPanel/NyxForge Studio"]
 layout_mode = 0
 offset_left = 185.13385
 offset_top = 144.55989
@@ -482,18 +411,18 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("7_flpep")
+icon = ExtResource("34_883rd")
 icon_alignment = 1
 expand_icon = true
 
-[node name="instagramButton2" type="Button" parent="SocialsPanel/NyxForge Studio"]
+[node name="instagramButton2" type="Button" parent="StartMenu/SocialsPanel/NyxForge Studio"]
 layout_mode = 0
 offset_left = 14.75565
 offset_top = 147.05228
 offset_right = 158.0137
 offset_bottom = 303.3028
 scale = Vector2(1.1234008, 1)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -505,40 +434,40 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("6_6aj3n")
+icon = ExtResource("32_ii1fg")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Dragonsight Studio" type="Label" parent="SocialsPanel"]
+[node name="Dragonsight Studio" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 22.998447
 offset_top = 13.66247
 offset_right = 976.9985
 offset_bottom = 153.66248
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 116
 text = "Dragonsight Studio"
 
-[node name="Email" type="Label" parent="SocialsPanel/Dragonsight Studio"]
+[node name="Email" type="Label" parent="StartMenu/SocialsPanel/Dragonsight Studio"]
 layout_mode = 0
 offset_left = 10.484792
 offset_top = 137.08263
 offset_right = 1038.4847
 offset_bottom = 277.08264
 scale = Vector2(0.8080646, 0.711797)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 77
 text = "Email: info@dragonsight.studio"
 
-[node name="instagramButton" type="Button" parent="SocialsPanel/Dragonsight Studio"]
+[node name="instagramButton" type="Button" parent="StartMenu/SocialsPanel/Dragonsight Studio"]
 layout_mode = 0
 offset_left = 10.48479
 offset_top = 209.36258
 offset_right = 153.7428
 offset_bottom = 365.6131
 scale = Vector2(1.1234008, 1)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -550,18 +479,18 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("6_6aj3n")
+icon = ExtResource("32_ii1fg")
 icon_alignment = 1
 expand_icon = true
 
-[node name="redditButton" type="Button" parent="SocialsPanel/Dragonsight Studio"]
+[node name="redditButton" type="Button" parent="StartMenu/SocialsPanel/Dragonsight Studio"]
 layout_mode = 0
 offset_left = 180.863
 offset_top = 206.87018
 offset_right = 324.12103
 offset_bottom = 363.12073
 scale = Vector2(1.1234008, 1)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -573,29 +502,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("11_dotjr")
+icon = ExtResource("37_nvrlp")
 icon_alignment = 1
 expand_icon = true
 
-[node name="GodSnail" type="Label" parent="SocialsPanel"]
+[node name="GodSnail" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 23.14562
 offset_top = 24.499176
 offset_right = 977.1456
 offset_bottom = 164.49918
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 116
 text = "GodSnail"
 
-[node name="soundCloudButton" type="Button" parent="SocialsPanel/GodSnail"]
+[node name="soundCloudButton" type="Button" parent="StartMenu/SocialsPanel/GodSnail"]
 layout_mode = 0
 offset_left = -7.863632
 offset_top = 124.620575
 offset_right = 135.39438
 offset_bottom = 280.87106
 scale = Vector2(1.3589534, 1.2096782)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -607,18 +536,18 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("12_8hnkv")
+icon = ExtResource("38_knt6f")
 icon_alignment = 1
 expand_icon = true
 
-[node name="bandLabButton" type="Button" parent="SocialsPanel/GodSnail"]
+[node name="bandLabButton" type="Button" parent="StartMenu/SocialsPanel/GodSnail"]
 layout_mode = 0
 offset_left = 193.96904
 offset_top = 142.06746
 offset_right = 337.22705
 offset_bottom = 298.31793
 scale = Vector2(1.0430766, 0.92849916)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -630,29 +559,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("13_1gelb")
+icon = ExtResource("39_pgrap")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Toxic_Humble" type="Label" parent="SocialsPanel"]
+[node name="Toxic_Humble" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 23.118765
 offset_top = 32.515392
 offset_right = 977.1188
 offset_bottom = 172.5154
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 116
 text = "Toxic_Humble"
 
-[node name="linkedInButton" type="Button" parent="SocialsPanel/Toxic_Humble"]
+[node name="linkedInButton" type="Button" parent="StartMenu/SocialsPanel/Toxic_Humble"]
 layout_mode = 0
 offset_left = 744.4032
 offset_top = -7.8432465
 offset_right = 887.6612
 offset_bottom = 148.40724
 scale = Vector2(1.3589534, 1.2096782)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -664,29 +593,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("14_1gelb")
+icon = ExtResource("40_kdcmi")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Phren" type="Label" parent="SocialsPanel"]
+[node name="Phren" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 1.846075
 offset_top = 29.26887
 offset_right = 955.84607
 offset_bottom = 169.26888
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 116
 text = "Phren"
 
-[node name="artStationButton" type="Button" parent="SocialsPanel/Phren"]
+[node name="artStationButton" type="Button" parent="StartMenu/SocialsPanel/Phren"]
 layout_mode = 0
 offset_left = 313.75464
 offset_top = -19.759632
 offset_right = 457.01263
 offset_bottom = 136.49086
 scale = Vector2(1.3589534, 1.2096782)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -698,29 +627,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("16_28ark")
+icon = ExtResource("41_kcw8g")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Rissa Baker" type="Label" parent="SocialsPanel"]
+[node name="Rissa Baker" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 1.7844137
 offset_top = 18.663555
 offset_right = 955.7844
 offset_bottom = 158.66356
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 116
 text = "Rissa Baker"
 
-[node name="instagramButton" type="Button" parent="SocialsPanel/Rissa Baker"]
+[node name="instagramButton" type="Button" parent="StartMenu/SocialsPanel/Rissa Baker"]
 layout_mode = 0
 offset_left = 614.3817
 offset_top = 0.987669
 offset_right = 757.6397
 offset_bottom = 157.23816
 scale = Vector2(1.3589534, 1.2096782)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("32_ii1fg")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -732,17 +661,17 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("6_6aj3n")
+icon = ExtResource("32_ii1fg")
 icon_alignment = 1
 expand_icon = true
 
-[node name="BackButton" type="Button" parent="SocialsPanel"]
+[node name="BackButton" type="Button" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 0.9397471
 offset_top = 0.97737557
 offset_right = 263.93976
 offset_bottom = 106.97738
 scale = Vector2(0.0267252, 0.035185397)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("29_fhwr0")
 theme_override_font_sizes/font_size = 88
 text = " Return "

--- a/Scenes/UI/start_menu_good_end.tscn
+++ b/Scenes/UI/start_menu_good_end.tscn
@@ -1,206 +1,123 @@
-[gd_scene load_steps=56 format=3 uid="uid://bf5g134nk8ebe"]
+[gd_scene load_steps=54 format=3 uid="uid://dr15be7ckx43q"]
 
-[ext_resource type="Script" uid="uid://ch3y31u7yadh8" path="res://Scripts/UI/start_menu.gd" id="1_juhg0"]
-[ext_resource type="Texture2D" uid="uid://jx3yb0oa748d" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/LighthouseAnim2.png" id="2_qpngb"]
-[ext_resource type="FontFile" uid="uid://bugymcbk132rp" path="res://Assets/Fonts/Fry's Baskerville Regular.otf" id="3_2ybwg"]
-[ext_resource type="Theme" uid="uid://b4lurv8njswua" path="res://Resources/theme.tres" id="3_3kyvb"]
-[ext_resource type="FontFile" uid="uid://n0n6mmkjc76j" path="res://Assets/Fonts/Eyesome Script.otf" id="3_8wf1d"]
-[ext_resource type="PackedScene" uid="uid://cnhqsrc4gxenp" path="res://Scenes/UI/options_panel.tscn" id="6_4j130"]
-[ext_resource type="Texture2D" uid="uid://cl5m1ag2c73rw" path="res://Socials/instagramLogo.png" id="6_6aj3n"]
-[ext_resource type="Texture2D" uid="uid://ofq8rlceejkj" path="res://Socials/itch.ioLogo.png" id="7_flpep"]
-[ext_resource type="Texture2D" uid="uid://nqv7yxtq17yu" path="res://Socials/X_TwitterLogo_Inverted.png" id="8_4j130"]
-[ext_resource type="Texture2D" uid="uid://clrkcs60j62i7" path="res://Socials/githubLogo.png" id="8_dapwv"]
-[ext_resource type="Texture2D" uid="uid://dyat81sk4l0my" path="res://Socials/TikTokLogo.png" id="9_flpep"]
-[ext_resource type="Texture2D" uid="uid://c183q4u3evnkt" path="res://Socials/RedditLogo.png" id="11_dotjr"]
-[ext_resource type="Texture2D" uid="uid://c4yt30qi4s5pu" path="res://Socials/soundCloudLogo.png" id="12_8hnkv"]
-[ext_resource type="Texture2D" uid="uid://da5s4no21relq" path="res://Socials/bandLabLogo.png" id="13_1gelb"]
-[ext_resource type="Texture2D" uid="uid://dby8t5470r2bp" path="res://Socials/linkedInLogo.png" id="14_1gelb"]
-[ext_resource type="Texture2D" uid="uid://wdrj1fxdpqm8" path="res://Socials/artStationLogo.png" id="16_28ark"]
+[ext_resource type="Script" uid="uid://ch3y31u7yadh8" path="res://Scripts/UI/start_menu.gd" id="1_pqm7c"]
+[ext_resource type="Texture2D" uid="uid://d4fb7d7jm5rhe" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0000.png" id="2_byq1f"]
+[ext_resource type="Texture2D" uid="uid://dag82cwskw1es" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0001.png" id="3_pl472"]
+[ext_resource type="Texture2D" uid="uid://b4hqwlpu6aarf" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0002.png" id="4_rsmwk"]
+[ext_resource type="Texture2D" uid="uid://ocvx1rx0i72i" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0003.png" id="5_gtwx7"]
+[ext_resource type="Texture2D" uid="uid://cvbgfm8510qxe" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0004.png" id="6_0x5vx"]
+[ext_resource type="Texture2D" uid="uid://c6wlkfg4usfiq" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0005.png" id="7_k1s5x"]
+[ext_resource type="Texture2D" uid="uid://duiyyqntwgvq5" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0006.png" id="8_nspfd"]
+[ext_resource type="Texture2D" uid="uid://dttwcgxh00tq8" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0007.png" id="9_twvpf"]
+[ext_resource type="Texture2D" uid="uid://2hif1te5drvr" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0008.png" id="10_8aywe"]
+[ext_resource type="Texture2D" uid="uid://cokscc1uccp35" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0009.png" id="11_3o00g"]
+[ext_resource type="Texture2D" uid="uid://c5dhwmyurnv5r" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0010.png" id="12_w3fy1"]
+[ext_resource type="Texture2D" uid="uid://dtkvf2t1jabe8" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0011.png" id="13_oxh34"]
+[ext_resource type="Texture2D" uid="uid://dlry0dxonxd6d" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0012.png" id="14_4hxsw"]
+[ext_resource type="Texture2D" uid="uid://bl8g04n5exj75" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0013.png" id="15_w32qx"]
+[ext_resource type="Texture2D" uid="uid://b5i1qiyy35twl" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0014.png" id="16_mgykj"]
+[ext_resource type="Texture2D" uid="uid://cxpf8ik41q1p2" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0015.png" id="17_7gpna"]
+[ext_resource type="Texture2D" uid="uid://ctv0j6s0jxwcx" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0016.png" id="18_m2dg5"]
+[ext_resource type="Texture2D" uid="uid://cptw2pgthr8ef" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0017.png" id="19_q6b6l"]
+[ext_resource type="Texture2D" uid="uid://dhetemuqfcgac" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0018.png" id="20_efuv4"]
+[ext_resource type="Texture2D" uid="uid://lku8wsywonyu" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0019.png" id="21_5jmip"]
+[ext_resource type="Texture2D" uid="uid://b8nv3gblify5i" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0020.png" id="22_f8chh"]
+[ext_resource type="Texture2D" uid="uid://bybff2tbqgsvf" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0021.png" id="23_uox4e"]
+[ext_resource type="Texture2D" uid="uid://bpccpxi5nwgji" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0022.png" id="24_fuuh3"]
+[ext_resource type="Texture2D" uid="uid://c0urklcc0rw0o" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0023.png" id="25_inu3d"]
+[ext_resource type="Texture2D" uid="uid://dpq5ctj3iqv8" path="res://Assets/Images/Lighthouse/AnimatedLightHouseScreen/Day Transition/frame0024.png" id="26_xiymb"]
+[ext_resource type="FontFile" uid="uid://n0n6mmkjc76j" path="res://Assets/Fonts/Eyesome Script.otf" id="27_jq56v"]
+[ext_resource type="Theme" uid="uid://b4lurv8njswua" path="res://Resources/theme.tres" id="28_g8i22"]
+[ext_resource type="FontFile" uid="uid://bugymcbk132rp" path="res://Assets/Fonts/Fry's Baskerville Regular.otf" id="29_iejyg"]
+[ext_resource type="PackedScene" uid="uid://cnhqsrc4gxenp" path="res://Scenes/UI/options_panel.tscn" id="30_p8lvo"]
+[ext_resource type="Texture2D" uid="uid://cl5m1ag2c73rw" path="res://Socials/instagramLogo.png" id="31_8sae8"]
+[ext_resource type="Texture2D" uid="uid://clrkcs60j62i7" path="res://Socials/githubLogo.png" id="32_nvuj2"]
+[ext_resource type="Texture2D" uid="uid://ofq8rlceejkj" path="res://Socials/itch.ioLogo.png" id="33_1wmh8"]
+[ext_resource type="Texture2D" uid="uid://nqv7yxtq17yu" path="res://Socials/X_TwitterLogo_Inverted.png" id="34_657ua"]
+[ext_resource type="Texture2D" uid="uid://dyat81sk4l0my" path="res://Socials/TikTokLogo.png" id="35_rg4fi"]
+[ext_resource type="Texture2D" uid="uid://c183q4u3evnkt" path="res://Socials/RedditLogo.png" id="36_lhbj6"]
+[ext_resource type="Texture2D" uid="uid://c4yt30qi4s5pu" path="res://Socials/soundCloudLogo.png" id="37_d0lg5"]
+[ext_resource type="Texture2D" uid="uid://da5s4no21relq" path="res://Socials/bandLabLogo.png" id="38_1nhc8"]
+[ext_resource type="Texture2D" uid="uid://dby8t5470r2bp" path="res://Socials/linkedInLogo.png" id="39_mynuw"]
+[ext_resource type="Texture2D" uid="uid://wdrj1fxdpqm8" path="res://Socials/artStationLogo.png" id="40_t5jje"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_8wf1d"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(0, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_2ybwg"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(480, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_3kyvb"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(960, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_fa70d"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(1440, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_j6k6k"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(1920, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6aj3n"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(2400, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_flpep"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(2880, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_4j130"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(3360, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_dotjr"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(3840, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_vxxty"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(4320, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_8hnkv"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(4800, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_1gelb"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(5280, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_dapwv"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(5760, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_28ark"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(6240, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_g8uic"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(6720, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_0v2ic"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(7200, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ee1bv"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(7680, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_sv1v3"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(8160, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_4rjbl"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(8640, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6q7j5"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(9120, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ho5tr"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(9600, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_mj5xc"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(10080, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_5tb6a"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(10560, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_82exy"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(11040, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6pru2"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(11520, 0, 480, 270)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_58o8m"]
-atlas = ExtResource("2_qpngb")
-region = Rect2(12000, 0, 480, 270)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_yxcpp"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_hc27g"]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_8wf1d")
+"texture": ExtResource("2_byq1f")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_2ybwg")
+"texture": ExtResource("3_pl472")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_3kyvb")
+"texture": ExtResource("4_rsmwk")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_fa70d")
+"texture": ExtResource("5_gtwx7")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_j6k6k")
+"texture": ExtResource("6_0x5vx")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_6aj3n")
+"texture": ExtResource("7_k1s5x")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_flpep")
+"texture": ExtResource("8_nspfd")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_4j130")
+"texture": ExtResource("9_twvpf")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_dotjr")
+"texture": ExtResource("10_8aywe")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_vxxty")
+"texture": ExtResource("11_3o00g")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_8hnkv")
+"texture": ExtResource("12_w3fy1")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_1gelb")
+"texture": ExtResource("13_oxh34")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_dapwv")
+"texture": ExtResource("14_4hxsw")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_28ark")
+"texture": ExtResource("15_w32qx")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_g8uic")
+"texture": ExtResource("16_mgykj")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_0v2ic")
+"texture": ExtResource("17_7gpna")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ee1bv")
+"texture": ExtResource("18_m2dg5")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_sv1v3")
+"texture": ExtResource("19_q6b6l")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_4rjbl")
+"texture": ExtResource("20_efuv4")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_6q7j5")
+"texture": ExtResource("21_5jmip")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ho5tr")
+"texture": ExtResource("22_f8chh")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_mj5xc")
+"texture": ExtResource("23_uox4e")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_5tb6a")
+"texture": ExtResource("24_fuuh3")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_82exy")
+"texture": ExtResource("25_inu3d")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_6pru2")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_58o8m")
+"texture": ExtResource("26_xiymb")
 }],
 "loop": true,
 "name": &"default",
@@ -232,8 +149,16 @@ bg_color = Color(0.13725491, 0.12156863, 0.1254902, 0.9019608)
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ee1bv"]
 
-[node name="StartMenu" type="Control"]
+[node name="Control" type="Control"]
 layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="StartMenu" type="Control" parent="."]
+layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -242,14 +167,14 @@ offset_right = 1.0
 offset_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_juhg0")
+script = ExtResource("1_pqm7c")
 
-[node name="TextureRect" type="AnimatedSprite2D" parent="."]
+[node name="TextureRect" type="AnimatedSprite2D" parent="StartMenu"]
 position = Vector2(575, 324)
 scale = Vector2(2.3999999, 2.4000003)
-sprite_frames = SubResource("SpriteFrames_yxcpp")
+sprite_frames = SubResource("SpriteFrames_hc27g")
 
-[node name="Title" type="RichTextLabel" parent="."]
+[node name="Title" type="RichTextLabel" parent="StartMenu"]
 texture_filter = 1
 layout_mode = 0
 offset_left = 509.0
@@ -258,13 +183,13 @@ offset_right = 1921.0
 offset_bottom = 894.0
 scale = Vector2(0.4954999, 0.5062728)
 theme_override_colors/default_color = Color(0.8745098, 0.8980392, 0.7294118, 1)
-theme_override_fonts/normal_font = ExtResource("3_8wf1d")
+theme_override_fonts/normal_font = ExtResource("27_jq56v")
 theme_override_font_sizes/normal_font_size = 512
 text = "Solais"
 scroll_active = false
 autowrap_mode = 0
 
-[node name="CenterContainer" type="CenterContainer" parent="."]
+[node name="CenterContainer" type="CenterContainer" parent="StartMenu"]
 layout_mode = 1
 offset_left = 464.0
 offset_top = 378.0
@@ -272,72 +197,72 @@ offset_right = 717.0
 offset_bottom = 689.0
 scale = Vector2(0.79494154, 0.8267256)
 
-[node name="Buttons" type="VBoxContainer" parent="CenterContainer"]
+[node name="Buttons" type="VBoxContainer" parent="StartMenu/CenterContainer"]
 texture_filter = 1
 layout_mode = 2
 theme_override_constants/separation = 4
 
-[node name="StartButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="StartButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("28_g8i22")
+theme_override_fonts/font = ExtResource("29_iejyg")
 theme_override_font_sizes/font_size = 49
 action_mode = 0
 text = " New Game "
 
-[node name="ContinueButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="ContinueButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("28_g8i22")
+theme_override_fonts/font = ExtResource("29_iejyg")
 theme_override_font_sizes/font_size = 49
 text = "Continue
 "
 
-[node name="OptionsButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="OptionsButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("28_g8i22")
+theme_override_fonts/font = ExtResource("29_iejyg")
 theme_override_font_sizes/font_size = 49
 text = "Options"
 
-[node name="SocialsButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="SocialsButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("28_g8i22")
+theme_override_fonts/font = ExtResource("29_iejyg")
 theme_override_font_sizes/font_size = 49
 text = "Links"
 
-[node name="QuitButton" type="Button" parent="CenterContainer/Buttons"]
+[node name="QuitButton" type="Button" parent="StartMenu/CenterContainer/Buttons"]
 texture_filter = 1
 layout_mode = 2
-theme = ExtResource("3_3kyvb")
-theme_override_fonts/font = ExtResource("3_2ybwg")
+theme = ExtResource("28_g8i22")
+theme_override_fonts/font = ExtResource("29_iejyg")
 theme_override_font_sizes/font_size = 49
 text = "Quit
 "
 
-[node name="OptionsPanel" parent="." instance=ExtResource("6_4j130")]
+[node name="OptionsPanel" parent="StartMenu" instance=ExtResource("30_p8lvo")]
 layout_mode = 0
 
-[node name="SocialsPanel" type="Panel" parent="."]
+[node name="SocialsPanel" type="Panel" parent="StartMenu"]
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 39.644794
 scale = Vector2(28.731138, 16.37037)
 theme_override_styles/panel = SubResource("StyleBoxFlat_flpep")
 
-[node name="githubRepoButton" type="Button" parent="SocialsPanel"]
+[node name="githubRepoButton" type="Button" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 17.518091
 offset_top = 17.172277
 offset_right = 160.77611
 offset_bottom = 173.42276
 scale = Vector2(0.027727112, 0.046241343)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -349,29 +274,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("8_dapwv")
+icon = ExtResource("32_nvuj2")
 icon_alignment = 1
 expand_icon = true
 
-[node name="CyberSugar" type="Label" parent="SocialsPanel"]
+[node name="CyberSugar" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 1.9142996
 offset_top = 7.387984
 offset_right = 955.9143
 offset_bottom = 147.38799
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 116
 text = "CyberSugar Studios"
 
-[node name="instagramButton" type="Button" parent="SocialsPanel/CyberSugar"]
+[node name="instagramButton" type="Button" parent="StartMenu/SocialsPanel/CyberSugar"]
 layout_mode = 0
 offset_left = 23.590847
 offset_top = 147.05228
 offset_right = 166.84886
 offset_bottom = 303.3028
 scale = Vector2(1.1234008, 1)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -383,11 +308,11 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("6_6aj3n")
+icon = ExtResource("31_8sae8")
 icon_alignment = 1
 expand_icon = true
 
-[node name="itchButton" type="Button" parent="SocialsPanel/CyberSugar"]
+[node name="itchButton" type="Button" parent="StartMenu/SocialsPanel/CyberSugar"]
 layout_mode = 0
 offset_left = 191.34787
 offset_top = 139.57506
@@ -405,11 +330,11 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("7_flpep")
+icon = ExtResource("33_1wmh8")
 icon_alignment = 1
 expand_icon = true
 
-[node name="xButton" type="Button" parent="SocialsPanel/CyberSugar"]
+[node name="xButton" type="Button" parent="StartMenu/SocialsPanel/CyberSugar"]
 layout_mode = 0
 offset_left = 364.34726
 offset_top = 147.05226
@@ -427,11 +352,11 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("8_4j130")
+icon = ExtResource("34_657ua")
 icon_alignment = 1
 expand_icon = true
 
-[node name="tikTokButton" type="Button" parent="SocialsPanel/CyberSugar"]
+[node name="tikTokButton" type="Button" parent="StartMenu/SocialsPanel/CyberSugar"]
 layout_mode = 0
 offset_left = 524.2407
 offset_top = 134.59023
@@ -449,22 +374,22 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("9_flpep")
+icon = ExtResource("35_rg4fi")
 icon_alignment = 1
 expand_icon = true
 
-[node name="NyxForge Studio" type="Label" parent="SocialsPanel"]
+[node name="NyxForge Studio" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 23.406216
 offset_top = 6.285019
 offset_right = 977.4062
 offset_bottom = 146.28502
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 116
 text = "NyxForge Studio"
 
-[node name="itchButton" type="Button" parent="SocialsPanel/NyxForge Studio"]
+[node name="itchButton" type="Button" parent="StartMenu/SocialsPanel/NyxForge Studio"]
 layout_mode = 0
 offset_left = 185.13385
 offset_top = 144.55989
@@ -482,18 +407,18 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("7_flpep")
+icon = ExtResource("33_1wmh8")
 icon_alignment = 1
 expand_icon = true
 
-[node name="instagramButton2" type="Button" parent="SocialsPanel/NyxForge Studio"]
+[node name="instagramButton2" type="Button" parent="StartMenu/SocialsPanel/NyxForge Studio"]
 layout_mode = 0
 offset_left = 14.75565
 offset_top = 147.05228
 offset_right = 158.0137
 offset_bottom = 303.3028
 scale = Vector2(1.1234008, 1)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -505,40 +430,40 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("6_6aj3n")
+icon = ExtResource("31_8sae8")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Dragonsight Studio" type="Label" parent="SocialsPanel"]
+[node name="Dragonsight Studio" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 22.998447
 offset_top = 13.66247
 offset_right = 976.9985
 offset_bottom = 153.66248
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 116
 text = "Dragonsight Studio"
 
-[node name="Email" type="Label" parent="SocialsPanel/Dragonsight Studio"]
+[node name="Email" type="Label" parent="StartMenu/SocialsPanel/Dragonsight Studio"]
 layout_mode = 0
 offset_left = 10.484792
 offset_top = 137.08263
 offset_right = 1038.4847
 offset_bottom = 277.08264
 scale = Vector2(0.8080646, 0.711797)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 77
 text = "Email: info@dragonsight.studio"
 
-[node name="instagramButton" type="Button" parent="SocialsPanel/Dragonsight Studio"]
+[node name="instagramButton" type="Button" parent="StartMenu/SocialsPanel/Dragonsight Studio"]
 layout_mode = 0
 offset_left = 10.48479
 offset_top = 209.36258
 offset_right = 153.7428
 offset_bottom = 365.6131
 scale = Vector2(1.1234008, 1)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -550,18 +475,18 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("6_6aj3n")
+icon = ExtResource("31_8sae8")
 icon_alignment = 1
 expand_icon = true
 
-[node name="redditButton" type="Button" parent="SocialsPanel/Dragonsight Studio"]
+[node name="redditButton" type="Button" parent="StartMenu/SocialsPanel/Dragonsight Studio"]
 layout_mode = 0
 offset_left = 180.863
 offset_top = 206.87018
 offset_right = 324.12103
 offset_bottom = 363.12073
 scale = Vector2(1.1234008, 1)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -573,29 +498,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("11_dotjr")
+icon = ExtResource("36_lhbj6")
 icon_alignment = 1
 expand_icon = true
 
-[node name="GodSnail" type="Label" parent="SocialsPanel"]
+[node name="GodSnail" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 23.14562
 offset_top = 24.499176
 offset_right = 977.1456
 offset_bottom = 164.49918
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 116
 text = "GodSnail"
 
-[node name="soundCloudButton" type="Button" parent="SocialsPanel/GodSnail"]
+[node name="soundCloudButton" type="Button" parent="StartMenu/SocialsPanel/GodSnail"]
 layout_mode = 0
 offset_left = -7.863632
 offset_top = 124.620575
 offset_right = 135.39438
 offset_bottom = 280.87106
 scale = Vector2(1.3589534, 1.2096782)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -607,18 +532,18 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("12_8hnkv")
+icon = ExtResource("37_d0lg5")
 icon_alignment = 1
 expand_icon = true
 
-[node name="bandLabButton" type="Button" parent="SocialsPanel/GodSnail"]
+[node name="bandLabButton" type="Button" parent="StartMenu/SocialsPanel/GodSnail"]
 layout_mode = 0
 offset_left = 193.96904
 offset_top = 142.06746
 offset_right = 337.22705
 offset_bottom = 298.31793
 scale = Vector2(1.0430766, 0.92849916)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -630,29 +555,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("13_1gelb")
+icon = ExtResource("38_1nhc8")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Toxic_Humble" type="Label" parent="SocialsPanel"]
+[node name="Toxic_Humble" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 23.118765
 offset_top = 32.515392
 offset_right = 977.1188
 offset_bottom = 172.5154
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 116
 text = "Toxic_Humble"
 
-[node name="linkedInButton" type="Button" parent="SocialsPanel/Toxic_Humble"]
+[node name="linkedInButton" type="Button" parent="StartMenu/SocialsPanel/Toxic_Humble"]
 layout_mode = 0
 offset_left = 744.4032
 offset_top = -7.8432465
 offset_right = 887.6612
 offset_bottom = 148.40724
 scale = Vector2(1.3589534, 1.2096782)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -664,29 +589,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("14_1gelb")
+icon = ExtResource("39_mynuw")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Phren" type="Label" parent="SocialsPanel"]
+[node name="Phren" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 1.846075
 offset_top = 29.26887
 offset_right = 955.84607
 offset_bottom = 169.26888
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 116
 text = "Phren"
 
-[node name="artStationButton" type="Button" parent="SocialsPanel/Phren"]
+[node name="artStationButton" type="Button" parent="StartMenu/SocialsPanel/Phren"]
 layout_mode = 0
 offset_left = 313.75464
 offset_top = -19.759632
 offset_right = 457.01263
 offset_bottom = 136.49086
 scale = Vector2(1.3589534, 1.2096782)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -698,29 +623,29 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("16_28ark")
+icon = ExtResource("40_t5jje")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Rissa Baker" type="Label" parent="SocialsPanel"]
+[node name="Rissa Baker" type="Label" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 1.7844137
 offset_top = 18.663555
 offset_right = 955.7844
 offset_bottom = 158.66356
 scale = Vector2(0.013278421, 0.024508782)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 116
 text = "Rissa Baker"
 
-[node name="instagramButton" type="Button" parent="SocialsPanel/Rissa Baker"]
+[node name="instagramButton" type="Button" parent="StartMenu/SocialsPanel/Rissa Baker"]
 layout_mode = 0
 offset_left = 614.3817
 offset_top = 0.987669
 offset_right = 757.6397
 offset_bottom = 157.23816
 scale = Vector2(1.3589534, 1.2096782)
-theme_override_icons/icon = ExtResource("6_6aj3n")
+theme_override_icons/icon = ExtResource("31_8sae8")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_flpep")
 theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_4j130")
 theme_override_styles/pressed = SubResource("StyleBoxEmpty_vxxty")
@@ -732,17 +657,17 @@ theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_28ark"
 theme_override_styles/disabled = SubResource("StyleBoxEmpty_g8uic")
 theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_0v2ic")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ee1bv")
-icon = ExtResource("6_6aj3n")
+icon = ExtResource("31_8sae8")
 icon_alignment = 1
 expand_icon = true
 
-[node name="BackButton" type="Button" parent="SocialsPanel"]
+[node name="BackButton" type="Button" parent="StartMenu/SocialsPanel"]
 layout_mode = 0
 offset_left = 0.9397471
 offset_top = 0.97737557
 offset_right = 263.93976
 offset_bottom = 106.97738
 scale = Vector2(0.0267252, 0.035185397)
-theme = ExtResource("3_3kyvb")
+theme = ExtResource("28_g8i22")
 theme_override_font_sizes/font_size = 88
 text = " Return "

--- a/Scripts/CookingMinigame/kitchen_puzzle.gd
+++ b/Scripts/CookingMinigame/kitchen_puzzle.gd
@@ -378,7 +378,7 @@ func StartRecipe(recipeName: String):
 	
 	currentRecipeName = recipeName #store in case of reset needed
 	
-	activeRecipe = recipes[recipeName]
+	activeRecipe = recipes[recipeName].duplicate(true) # break link here to master list for resetting later
 	currentStepIndex = 0
 	recipeQuality = 100
 	

--- a/Scripts/Main/switch_decision_detector.gd
+++ b/Scripts/Main/switch_decision_detector.gd
@@ -38,7 +38,6 @@ func _process(_delta):
 	
 	if playerBody:
 		if Input.is_action_just_pressed("ui_accept") and GameManager.needLight:
-			GameManager.usedKitchen = true
 			#Dialogue system
 			GameManager.player.set_physics_process(false)
 			OnBodyExited(playerBody)

--- a/Scripts/Morse Puzzle/morse_puzzle.gd
+++ b/Scripts/Morse Puzzle/morse_puzzle.gd
@@ -21,7 +21,7 @@ const DAY_SENTENCES := {
 	1: "FISHING SEASON",
 	2: "QUIET SEAS",
 	3: "WL56 INCOMING SHIPMENT",
-	4: "SVAEDISH DELIVERY",
+	4: "SVAEDISH DULIVERY",
 }
 
 const MORSE: Dictionary[String, String] = {

--- a/Scripts/UI/CutsceneManager.gd
+++ b/Scripts/UI/CutsceneManager.gd
@@ -3,7 +3,8 @@ extends Node
 var nextDayIndex: int = -1
 
 var mainGameScenePath: String = "res://Scenes/main.tscn"
-var mainMenuScenePath: String = "res://Scenes/UI/start_menu.tscn"
+var goodEndMenuPath: String = "res://Scenes/UI/start_menu_good_end.tscn"
+var badEndMenuPath: String = "res://Scenes/UI/start_menu_bad_end.tscn"
 
 func PlayCutscene(cutscenePath: String, dayToStartAfter: int = -1):
 	if dayToStartAfter != -1:
@@ -15,10 +16,16 @@ func FinishCutscene():
 	get_tree().change_scene_to_file(mainGameScenePath)
 
 func EndGame():
-	if ResourceLoader.exists(mainMenuScenePath):
-		get_tree().change_scene_to_file(mainMenuScenePath)
+	if GameManager.isBadEnding:
+		if ResourceLoader.exists(badEndMenuPath):
+			get_tree().change_scene_to_file(badEndMenuPath)
+		else:
+			get_tree().quit()
 	else:
-		get_tree().quit()
+		if ResourceLoader.exists(goodEndMenuPath):
+			get_tree().change_scene_to_file(goodEndMenuPath)
+		else:
+			get_tree().quit()
 
 func CheckForPendingDayStart():
 	if nextDayIndex != -1:

--- a/Scripts/UI/sleep_screen.gd
+++ b/Scripts/UI/sleep_screen.gd
@@ -52,7 +52,10 @@ func _ready():
 	# Start Animation after a short delay
 	await get_tree().create_timer(1.0).timeout
 	
-	UpdateValues()
+	if moralityEnd == moralityStart and relationshipEnd == relationshipStart:
+		AllowToProceed()
+	else:
+		UpdateMorality()
 
 func DetermineDayText():
 	match GameManager.currentDay:
@@ -79,9 +82,9 @@ func DetermineDayText():
 		_:
 			choiceText = "Tonight, the night passes..."
 
-func UpdateValues():
-	if moralityStart == moralityEnd and relationshipStart == relationshipEnd:
-		AllowToProceed()
+func UpdateMorality():
+	if moralityStart == moralityEnd:
+		UpdateRelationship()
 		return
 	
 	var tween = create_tween()
@@ -97,9 +100,16 @@ func UpdateValues():
 	
 	tween.tween_interval(0.5)
 	
-	tween.tween_callback(func():
-		if relationshipStart != relationshipEnd:
-			countSoundPlayer.play())
+	tween.finished.connect(UpdateRelationship)
+
+func UpdateRelationship():
+	if relationshipStart == relationshipEnd:
+		AllowToProceed()
+		return
+	
+	var tween = create_tween()
+	if relationshipStart != relationshipEnd:
+		countSoundPlayer.play()
 	
 	tween.tween_method(func(val):
 		relationshipLabel.text = str(int(val)), 
@@ -107,6 +117,8 @@ func UpdateValues():
 		relationshipEnd, 
 		4.2
 	).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
+	
+	tween.tween_interval(0.5)
 	
 	tween.finished.connect(AllowToProceed)
 
@@ -135,10 +147,16 @@ func LoadNextDay():
 		if String(key).contains("goToBed"):
 			TaskManager.CompleteTask(key)
 	
+	if GameManager.currentDay == 4:
+		if GameManager.morality < 50:
+			GameManager.isBadEnding = true
+		else:
+			GameManager.isBadEnding = false
+	
 	GameManager.StartDay(GameManager.currentDay + 1)
 	
-	if GameManager.morality < 50:
-		GameManager.isBadEnding = true
+	if GameManager.isBadEnding:
+		return
 	
 	if ResourceLoader.exists(mainGameScenePath):
 		SceneLoader.change_scene_with_loading(mainGameScenePath)


### PR DESCRIPTION
- gear noises now loop
- added animated snow to dinner table scene
- added alternate start menus to be loaded after credits roll, good and bad
- fixed kitchen minigame retry by duplicating recipe array to protect the master list from the clean up step
- fixed kitchen 'e' key prompt by removing usedKitchen flag from light switch area
- added more misspelling to delivery in day 4 morse
- cutscene manager now chooses which start menu to load after ending
- changed sleep screen calculations to skip animations on unchanged morality or relationship
- changed sleep screen calculations of ending to correctly play good/bad ending on game end